### PR TITLE
feat: add bundle configuration support

### DIFF
--- a/src/amplifier_cli_tools/config.py
+++ b/src/amplifier_cli_tools/config.py
@@ -60,7 +60,8 @@ class DevConfig:
     Attributes:
         use_tmux: Whether to use tmux (False = run amplifier directly)
         repos: List of git repository URLs to clone
-        main_command: Command to run in the main window
+        bundle: Bundle to use (e.g., "amplifier-dev" for ecosystem development)
+        main_command: Command to run in the main window (bundle is inserted automatically)
         default_prompt: Default prompt to send after main_command starts
         agents_template: Path to custom AGENTS.md template, empty = use built-in
         windows: List of additional tmux windows to create
@@ -68,6 +69,7 @@ class DevConfig:
 
     use_tmux: bool
     repos: list[str]
+    bundle: str  # Bundle name, empty = no bundle flag
     main_command: str
     default_prompt: str
     agents_template: str  # Path to custom template, empty = use built-in
@@ -115,6 +117,7 @@ def _get_hardcoded_fallback() -> Config:
                 "https://github.com/microsoft/amplifier-core.git",
                 "https://github.com/microsoft/amplifier-foundation.git",
             ],
+            bundle="amplifier-dev",
             main_command="amplifier run --mode chat",
             default_prompt="",
             agents_template="",
@@ -150,6 +153,7 @@ def get_default_config() -> Config:
         dev=DevConfig(
             use_tmux=dev_data.get("use_tmux", True),
             repos=dev_data.get("repos", []),
+            bundle=dev_data.get("bundle", "amplifier-dev"),
             main_command=dev_data.get("main_command", ""),
             default_prompt=dev_data.get("default_prompt", ""),
             agents_template=dev_data.get("agents_template", ""),
@@ -213,6 +217,7 @@ def load_config(config_path: Path | None = None) -> Config:
     dev_config = DevConfig(
         use_tmux=dev_data.get("use_tmux", defaults.dev.use_tmux),
         repos=dev_data.get("repos", defaults.dev.repos),
+        bundle=dev_data.get("bundle", defaults.dev.bundle),
         main_command=dev_data.get("main_command", defaults.dev.main_command),
         default_prompt=dev_data.get("default_prompt", defaults.dev.default_prompt),
         agents_template=_expand_path(

--- a/src/amplifier_cli_tools/templates/default-config.toml
+++ b/src/amplifier_cli_tools/templates/default-config.toml
@@ -12,7 +12,11 @@ repos = [
     "https://github.com/microsoft/amplifier-foundation.git",
 ]
 
-# Command to run in main window
+# Bundle to use for Amplifier ecosystem development
+# Uses foundation:bundles/amplifier-dev.yaml which includes shadow integration
+bundle = "amplifier-dev"
+
+# Command to run in main window (bundle is inserted automatically if set)
 main_command = "amplifier run --mode chat"
 
 # Default prompt (empty = no auto-prompt)


### PR DESCRIPTION
## Summary

Adds bundle configuration support to the `amplifier-dev` command. Now automatically uses the `amplifier-dev` bundle from amplifier-foundation for ecosystem development work.

## Changes

### Config (`config.py`)
- Added `bundle: str` field to `DevConfig` dataclass
- Default value: `"amplifier-dev"`
- Parsed from `~/.amplifier-cli-tools.toml` if present

### Command Builder (`dev.py`)
- Added `build_main_command(config)` function
- Inserts `--bundle <name>` after `amplifier run` if bundle is configured
- Removed unused `run` import (LSP cleanup)

### Default Config (`default-config.toml`)
- Added `bundle = "amplifier-dev"` option with documentation

## How It Works

```toml
# ~/.amplifier-cli-tools.toml
[dev]
bundle = "amplifier-dev"  # NEW - defaults to this
main_command = "amplifier run --mode chat"
```

Results in:
```bash
amplifier run --bundle amplifier-dev --mode chat
```

## Usage

```bash
# Uses amplifier-dev bundle automatically
amplifier-dev ~/work/my-feature

# Override bundle in config
[dev]
bundle = "foundation"  # Use plain foundation instead
```

## Related PRs

- amplifier-foundation: microsoft/amplifier-foundation#18 (adds the amplifier-dev bundle)
