### PR TITLE
Add tab rename with color picker feature

### DIFF
--- a/src/amplifier_cli_tools/templates/wezterm.lua
+++ b/src/amplifier_cli_tools/templates/wezterm.lua
@@ -27,6 +27,56 @@ config.initial_cols = 140
 -- Tabs
 config.hide_tab_bar_if_only_one_tab = true
 
+-- Tab colors (Catppuccin Mocha palette) for colored tab names
+local tab_colors = {
+	red = { bg = "#f38ba8", fg = "#1e1e2e" },
+	green = { bg = "#a6e3a1", fg = "#1e1e2e" },
+	blue = { bg = "#89b4fa", fg = "#1e1e2e" },
+	yellow = { bg = "#f9e2af", fg = "#1e1e2e" },
+	purple = { bg = "#cba6f7", fg = "#1e1e2e" },
+	pink = { bg = "#f5c2e7", fg = "#1e1e2e" },
+	orange = { bg = "#fab387", fg = "#1e1e2e" },
+	teal = { bg = "#94e2d5", fg = "#1e1e2e" },
+}
+
+-- Format tab titles with optional colors
+-- Supports "name:color" format (e.g., "Server:blue", "Dev:red")
+wezterm.on("format-tab-title", function(tab)
+	local title = tab.tab_title
+	local color = nil
+
+	if title and #title > 0 then
+		-- Check for "name:color" format
+		local name, col = title:match("^(.+):(%w+)$")
+		if name and tab_colors[col] then
+			title = name
+			color = tab_colors[col]
+		end
+	else
+		title = tab.active_pane.title
+		-- Remove .exe extension and path
+		title = title:gsub("%.exe$", ""):gsub(".*[/\\]", "")
+		-- Capitalize first letter
+		if #title > 0 then
+			title = title:sub(1, 1):upper() .. title:sub(2)
+		end
+	end
+
+	-- Add padding
+	title = "  " .. title .. "  "
+
+	-- Return with color if specified
+	if color then
+		return {
+			{ Background = { Color = color.bg } },
+			{ Foreground = { Color = color.fg } },
+			{ Text = title },
+		}
+	end
+
+	return title
+end)
+
 -- Scrollback (tmux handles this, but nice for non-tmux use)
 config.scrollback_lines = 50000
 
@@ -43,6 +93,97 @@ config.keys = {
 	-- Clear scrollback (Cmd+K on mac, Ctrl+Shift+K elsewhere)
 	{ key = "k", mods = "CMD", action = wezterm.action.ClearScrollback("ScrollbackAndViewport") },
 	{ key = "k", mods = "CTRL|SHIFT", action = wezterm.action.ClearScrollback("ScrollbackAndViewport") },
+
+	-- Rename tab with color picker (Cmd+Shift+R on Mac, Ctrl+Shift+R elsewhere)
+	-- Leave name blank to keep current name and just change color
+	{
+		key = "r",
+		mods = "CMD|SHIFT",
+		action = wezterm.action.PromptInputLine({
+			description = "Enter tab name (blank = keep current) → then pick color  [ESC to cancel]",
+			action = wezterm.action_callback(function(window, pane, input)
+				if input == nil then
+					return
+				end
+				local name = input
+				if #name == 0 then
+					local current = window:active_tab():get_title()
+					name = current:match("^(.+):%w+$") or current
+					if #name == 0 then
+						name = pane:get_title():gsub("%.exe$", ""):gsub(".*[/\\]", "")
+					end
+				end
+				window:perform_action(
+					wezterm.action.InputSelector({
+						title = "Pick a tab color  [ESC to cancel]",
+						choices = {
+							{ label = "⬜  Default (no color)" },
+							{ label = "🔴  Red", id = "red" },
+							{ label = "🟢  Green", id = "green" },
+							{ label = "🔵  Blue", id = "blue" },
+							{ label = "🟡  Yellow", id = "yellow" },
+							{ label = "🟣  Purple", id = "purple" },
+							{ label = "🩷  Pink", id = "pink" },
+							{ label = "🟠  Orange", id = "orange" },
+							{ label = "🩵  Teal", id = "teal" },
+						},
+						action = wezterm.action_callback(function(window, pane, id)
+							if id then
+								window:active_tab():set_title(name .. ":" .. id)
+							else
+								window:active_tab():set_title(name)
+							end
+						end),
+					}),
+					pane
+				)
+			end),
+		}),
+	},
+	{
+		key = "r",
+		mods = "CTRL|SHIFT",
+		action = wezterm.action.PromptInputLine({
+			description = "Enter tab name (blank = keep current) → then pick color  [ESC to cancel]",
+			action = wezterm.action_callback(function(window, pane, input)
+				if input == nil then
+					return
+				end
+				local name = input
+				if #name == 0 then
+					local current = window:active_tab():get_title()
+					name = current:match("^(.+):%w+$") or current
+					if #name == 0 then
+						name = pane:get_title():gsub("%.exe$", ""):gsub(".*[/\\]", "")
+					end
+				end
+				window:perform_action(
+					wezterm.action.InputSelector({
+						title = "Pick a tab color  [ESC to cancel]",
+						choices = {
+							{ label = "⬜  Default (no color)" },
+							{ label = "🔴  Red", id = "red" },
+							{ label = "🟢  Green", id = "green" },
+							{ label = "🔵  Blue", id = "blue" },
+							{ label = "🟡  Yellow", id = "yellow" },
+							{ label = "🟣  Purple", id = "purple" },
+							{ label = "🩷  Pink", id = "pink" },
+							{ label = "🟠  Orange", id = "orange" },
+							{ label = "🩵  Teal", id = "teal" },
+						},
+						action = wezterm.action_callback(function(window, pane, id)
+							if id then
+								window:active_tab():set_title(name .. ":" .. id)
+							else
+								window:active_tab():set_title(name)
+							end
+						end),
+					}),
+					pane
+				)
+			end),
+		}),
+	},
 }
 
 -- Platform-specific adjustments


### PR DESCRIPTION
## Summary

Adds the ability to rename WezTerm tabs with optional color coding using a two-step interactive flow.

- **Cmd+Shift+R** (Mac) / **Ctrl+Shift+R** (Win/Linux) to rename tabs
- Two-step flow: enter name → pick color from list
- Leave name blank to keep current name and just change color
- 8 Catppuccin Mocha colors with emoji previews: 🔴 red, 🟢 green, 🔵 blue, 🟡 yellow, 🟣 purple, 🩷 pink, 🟠 orange, 🩵 teal
- ESC to cancel at any step

## Demo

1. Press `Cmd+Shift+R` (or `Ctrl+Shift+R`)
2. Enter tab name (or leave blank to keep current)
3. Select a color from the picker
4. Tab updates with name and color

## Implementation

- Colors stored as `name:color` format in tab title
- `format-tab-title` event parses and applies colors
- Uses Catppuccin Mocha palette to match existing theme

## Test plan

- [ ] Test rename with new name + color on macOS
- [ ] Test rename with blank name (color only) on macOS  
- [ ] Test ESC cancellation at both steps
- [ ] Test on Windows/Linux with Ctrl+Shift+R

🤖 Generated with [Claude Code](https://claude.com/claude-code)