### PR TITLE
fix: resolve tmux+WezTerm clipboard issues on Linux/Raspberry Pi

### DIFF
--- a/src/amplifier_cli_tools/setup.py
+++ b/src/amplifier_cli_tools/setup.py
@@ -314,6 +314,66 @@ def ensure_local_bin_in_path() -> None:
         print('  export PATH="$HOME/.local/bin:$PATH"')
 
 
+def _try_reload_tmux() -> bool:
+    """Reload tmux config if a server is already running.
+
+    Runs `tmux source-file ~/.tmux.conf` so that live sessions pick up the
+    updated config without needing a full restart.
+
+    Returns:
+        True if reload succeeded, False if no server is running or on error.
+    """
+    import subprocess
+
+    wrapper_conf = Path.home() / ".tmux.conf"
+    result = subprocess.run(
+        ["tmux", "source-file", str(wrapper_conf)],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def ensure_clipboard_tool(interactive: bool = True) -> bool:
+    """Ensure a clipboard bridge tool is installed on Linux.
+
+    On Linux, tmux vi copy-mode uses xclip or xsel to write to the X11
+    clipboard.  Without one, yanked text only lands in tmux's internal buffer
+    (though OSC 52 still lets WezTerm paste via set-clipboard on).
+
+    This is a no-op on macOS and Windows where clipboard access works natively.
+
+    Args:
+        interactive: If True, prompt user before installing.
+
+    Returns:
+        True if a clipboard tool is available (or not needed on this OS).
+    """
+    if platform.system() != "Linux":
+        return True  # Not needed on macOS / Windows
+
+    if command_exists("xclip") or command_exists("xsel"):
+        print("Clipboard tool already installed (xclip/xsel found).")
+        return True
+
+    print("No clipboard bridge found (xclip / xsel).")
+    print("  tmux copy-mode uses this to write to the system clipboard on Linux.")
+    print("  Clipboard will still work via OSC 52 (WezTerm + allow-passthrough),")
+    print("  but having xclip gives a more reliable fallback.")
+
+    if interactive:
+        response = input("Install xclip? [Y/n] ").strip().lower()
+        if response not in ("", "y", "yes"):
+            print("Skipping xclip.")
+            return True
+
+    success = try_install_tool("xclip")
+    if not success:
+        print("Note: install manually with:  sudo apt install xclip")
+        print("      Copy-paste will still work via WezTerm OSC 52 passthrough.")
+    return success
+
+
 def run_setup(
     interactive: bool = True, skip_tools: bool = False, skip_tmux: bool = False
 ) -> bool:
@@ -352,6 +412,17 @@ def run_setup(
     if not skip_tmux:
         print("Checking tmux configuration...")
         ensure_tmux_conf()
+        # Try to hot-reload the config in any running tmux server
+        if _try_reload_tmux():
+            print("Reloaded tmux config (running sessions updated).")
+        else:
+            print("Note: restart tmux or run:  tmux source ~/.tmux.conf")
+        print()
+
+    # Clipboard bridge (Linux only - xclip/xsel for tmux copy-mode)
+    if not skip_tools:
+        print("Checking clipboard tools...")
+        ensure_clipboard_tool(interactive)
         print()
 
     # Setup WezTerm config (if WezTerm is installed)
@@ -391,6 +462,7 @@ __all__ = [
     "check_and_install_tools",
     "ensure_tmux_conf",
     "ensure_wezterm_conf",
+    "ensure_clipboard_tool",
     "quick_check",
     "REQUIRED_TOOLS",
     "OPTIONAL_TOOLS",

--- a/src/amplifier_cli_tools/shell.py
+++ b/src/amplifier_cli_tools/shell.py
@@ -156,6 +156,14 @@ _TOOL_PACKAGES: dict[str, dict[str, str]] = {
         "apt": "mosh",
         "dnf": "mosh",
     },
+    "xclip": {
+        "apt": "xclip",
+        "dnf": "xclip",
+    },
+    "xsel": {
+        "apt": "xsel",
+        "dnf": "xsel",
+    },
 }
 
 

--- a/src/amplifier_cli_tools/templates/minimal-tmux.conf
+++ b/src/amplifier_cli_tools/templates/minimal-tmux.conf
@@ -37,7 +37,14 @@ set -g renumber-windows on
 # Vi copy-mode (optional, but nice)
 setw -g mode-keys vi
 bind -T copy-mode-vi v send -X begin-selection
-bind -T copy-mode-vi y send -X copy-selection-and-cancel
+# Yank to system clipboard: use xclip when available (Linux), else OSC 52 via set-clipboard
+if-shell 'command -v xclip' \
+    "bind -T copy-mode-vi y send -X copy-pipe-and-cancel 'xclip -in -selection clipboard'" \
+    "bind -T copy-mode-vi y send -X copy-selection-and-cancel"
+# Also yank on mouse drag release (requires mouse on)
+if-shell 'command -v xclip' \
+    "bind -T copy-mode-vi MouseDragEnd1Pane send -X copy-pipe-and-cancel 'xclip -in -selection clipboard'" \
+    "bind -T copy-mode-vi MouseDragEnd1Pane send -X copy-selection-and-cancel"
 
 # Easy pane navigation with Alt+arrow (no prefix needed)
 bind -n M-Left select-pane -L


### PR DESCRIPTION
## Problem

When `amplifier-dev` launches a tmux session, tmux intercepts all mouse and keyboard events. This breaks the normal copy-paste flow in WezTerm — selected text never reaches the terminal's clipboard, and pasting appears broken.

There were two interrelated gaps:

1. **Missing clipboard bridge on Linux** — tmux's vi copy-mode needs `xclip` or `xsel` to write yanked text into the X11/Wayland system clipboard. Neither was installable via `amplifier-dev setup`, and there was no guidance to install them.
2. **Static copy-mode bindings** — the `y` key was bound to `copy-selection-and-cancel`, which copies into tmux's *internal* buffer only. When `xclip` is available the correct primitive is `copy-pipe-and-cancel`, which simultaneously pipes to `xclip` and clears the selection.

> **Note:** the tmux config template already had the right server-side settings (`set-clipboard on` + `allow-passthrough on`) for the WezTerm OSC 52 path. The bindings and the installer were the missing pieces.

---

## Changes

### `src/amplifier_cli_tools/shell.py`

Added `xclip` and `xsel` to `_TOOL_PACKAGES` (apt + dnf), so `try_install_tool()` can auto-install them. Previously the installer had no mapping for either package.

```python
"xclip": {"apt": "xclip", "dnf": "xclip"},
"xsel":  {"apt": "xsel",  "dnf": "xsel"},
```

---

### `src/amplifier_cli_tools/setup.py`

**New: `ensure_clipboard_tool(interactive)`**

A Linux-only check (no-op on macOS/Windows) that:
- Returns immediately if `xclip` or `xsel` is already on `PATH`
- Otherwise explains why it's needed and offers to install `xclip`
- On refusal or failure, reassures the user that WezTerm OSC 52 passthrough still works as a fallback

**New: `_try_reload_tmux()`**

Runs `tmux source-file ~/.tmux.conf` after writing the config file. If a tmux server is already running, the new bindings take effect immediately — no need to kill and restart the session.

**Updated: `run_setup()`**

Both new functions are called in `run_setup()`, inserted between the tmux config step and the WezTerm config step:

```
Checking tmux configuration...
  Updated base config: ...
  Reloaded tmux config (running sessions updated).   ← new

Checking clipboard tools...                          ← new (Linux only)
  Clipboard tool already installed (xclip/xsel found).

Checking WezTerm configuration...
```

---

### `src/amplifier_cli_tools/templates/minimal-tmux.conf`

Replaced the static `copy-selection-and-cancel` binding with `if-shell` guards so the config adapts at load time:

```tmux
# Yank to system clipboard: use xclip when available (Linux), else OSC 52 via set-clipboard
if-shell 'command -v xclip' \
    "bind -T copy-mode-vi y send -X copy-pipe-and-cancel 'xclip -in -selection clipboard'" \
    "bind -T copy-mode-vi y send -X copy-selection-and-cancel"

# Also yank on mouse drag release (requires mouse on)
if-shell 'command -v xclip' \
    "bind -T copy-mode-vi MouseDragEnd1Pane send -X copy-pipe-and-cancel 'xclip -in -selection clipboard'" \
    "bind -T copy-mode-vi MouseDragEnd1Pane send -X copy-selection-and-cancel"
```

The `if-shell` is evaluated once when the config loads, so there is no runtime overhead per keypress.

---

## Clipboard paths after this fix

| Scenario | Mechanism | Result |
|---|---|---|
| Linux + xclip installed | `copy-pipe-and-cancel` → xclip | ✅ System clipboard |
| Linux, no xclip, WezTerm+SSH | OSC 52 via `set-clipboard on` + `allow-passthrough on` | ✅ WezTerm clipboard |
| macOS | OSC 52 (always supported) | ✅ System clipboard |
| Shift+drag (any platform) | WezTerm native selection (bypasses tmux) | ✅ Immediate workaround |

---

## Testing

**On Raspberry Pi / Ubuntu (apt):**
```bash
amplifier-dev setup        # now installs xclip if missing, reloads tmux live
# enter copy-mode, v to select, y to yank → paste in WezTerm with Ctrl+Shift+V
```

**On macOS:** setup unchanged, no xclip prompt shown.

**On a machine with an existing tmux session:**
```bash
amplifier-dev setup        # reloads tmux.conf in-place, no restart needed
```